### PR TITLE
Make sure that decoded value is an array

### DIFF
--- a/EventListener/RequestTransformerListener.php
+++ b/EventListener/RequestTransformerListener.php
@@ -45,7 +45,7 @@ class RequestTransformerListener implements RequestListenerInterface
     {
         $data = json_decode($request->getContent(), true);
 
-        if (json_last_error() !== JSON_ERROR_NONE) {
+        if (json_last_error() !== JSON_ERROR_NONE || ($data && !is_array($data))) {
             return false;
         }
 

--- a/EventListener/RequestTransformerListener.php
+++ b/EventListener/RequestTransformerListener.php
@@ -45,11 +45,11 @@ class RequestTransformerListener implements RequestListenerInterface
     {
         $data = json_decode($request->getContent(), true);
 
-        if (json_last_error() !== JSON_ERROR_NONE || ($data && !is_array($data))) {
+        if (json_last_error() !== JSON_ERROR_NONE) {
             return false;
         }
 
-        if (null !== $data) {
+        if (is_array($data)) {
             $request->request->replace($data);
         }
 

--- a/Tests/EventListener/RequestTransformerListenerTest.php
+++ b/Tests/EventListener/RequestTransformerListenerTest.php
@@ -33,6 +33,22 @@ class RequestTransformerListenerTest extends TestCase
         $this->assertNull($event->getResponse());
     }
 
+    /**
+     * @dataProvider jsonContentTypes
+     */
+    public function testDoNotTransformRequestContainingScalarJsonValueA($contentType)
+    {
+        $content = json_encode('foo');
+        $request = $this->createRequest($contentType, $content);
+        $event = $this->createGetResponseEventMock($request);
+
+        $this->listener->onKernelRequest($event);
+
+        $this->assertEquals([], $event->getRequest()->request->all());
+        $this->assertEquals($content, $event->getRequest()->getContent());
+        $this->assertEquals(400, $event->getResponse()->getStatusCode());
+    }
+
     public function testBadRequestResponse()
     {
         $request = $this->createRequest('application/json', '{maaan}');

--- a/Tests/EventListener/RequestTransformerListenerTest.php
+++ b/Tests/EventListener/RequestTransformerListenerTest.php
@@ -36,7 +36,7 @@ class RequestTransformerListenerTest extends TestCase
     /**
      * @dataProvider jsonContentTypes
      */
-    public function testDoNotTransformRequestContainingScalarJsonValueA($contentType)
+    public function testDoNotTransformRequestContainingScalarJsonValue($contentType)
     {
         $content = json_encode('foo');
         $request = $this->createRequest($contentType, $content);
@@ -46,7 +46,6 @@ class RequestTransformerListenerTest extends TestCase
 
         $this->assertEquals([], $event->getRequest()->request->all());
         $this->assertEquals($content, $event->getRequest()->getContent());
-        $this->assertEquals(400, $event->getResponse()->getStatusCode());
     }
 
     public function testBadRequestResponse()


### PR DESCRIPTION
It is technically valid to encode a scalar value in JSON. In that case, there are no decoding errors (so you get `JSON_ERROR_NONE` when decoding), but as the data is not an array, the call to `$request->request->replace()`` will result in an internal server error, as `replace()` is typehinted to expect an array as argument 1. Therefore, an explicit check is required and added with this commit.

_Note:_ with this change, a scalar value encoded in JSON will result in a “Bad Request“ response. Technically, this might be arguable, but I think semantically, this makes sense. But maybe you want to change that.