### PR TITLE
Make listener priority configurable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,6 +30,9 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('request_transformer')
                             ->defaultValue(RequestTransformerListener::class)
                         ->end()
+                        ->scalarNode('priority')
+                            ->defaultValue(100)
+                        ->end()
                     ->end()
                 ->end()
             ->end();

--- a/DependencyInjection/JsonRequestExtension.php
+++ b/DependencyInjection/JsonRequestExtension.php
@@ -18,7 +18,7 @@ class JsonRequestExtension extends ConfigurableExtension
         $listener->addTag('kernel.event_listener', [
             'event' => 'kernel.request',
             'method' => 'onKernelRequest',
-            'priority' => 100,
+            'priority' => $configs['listener']['priority'],
         ]);
 
         $container->setDefinition('sb_json_request.request_transformer', $listener);


### PR DESCRIPTION
Symfony has a AddRequestFormatListener registered as priority 1, which happens after this is registered.

We have some additional json content types we register against the framework, which aren't picked up by this listener with it's existing priority.