### PR TITLE
Fix the deprecation notice on the TreeBuilder added in Symfony 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ php:
 env:
     - SYMFONY_VERSION=3.4.*
     - SYMFONY_VERSION=4.0.*
-    - SYMFONY_VERSION=4.1.* DEPENDENCIES=dev
+    - SYMFONY_VERSION=4.1.*
+    - SYMFONY_VERSION=4.2.* DEPENDENCIES=dev
 
 cache:
     directories:

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -13,9 +13,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('sb_json_request');
 
-        $builder->root('sb_json_request')
+        $builder->getRootNode()
             ->children()
                 ->arrayNode('listener')
                     ->addDefaultsIfNotSet()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,7 +15,14 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('sb_json_request');
 
-        $builder->getRootNode()
+        if (\method_exists($builder, 'getRootNode')) {
+            $rootNode = $builder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $builder->root('maker');
+        }
+
+        $rootNode
             ->children()
                 ->arrayNode('listener')
                     ->addDefaultsIfNotSet()


### PR DESCRIPTION
This deprecation makes unit tests fail on our project.

See https://symfony.com/blog/new-in-symfony-4-2-important-deprecations